### PR TITLE
execute toggleDotFiles only on dired editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       {
         "key": ".",
         "command": "extension.dired.toggleDotFiles",
-        "when": "editorTextFocus && !inDebugRepl"
+        "when": "dired.open && editorTextFocus && !inDebugRepl"
       },
       {
         "key": "ctrl+x f",


### PR DESCRIPTION
I broke vscode-dired. The dot keybinding applied to all editors
making them unusable.
Sorry about that.
This should fix it.