### PR TITLE
Support highlighting foldere name and file extension 

### DIFF
--- a/dired.tmLanguage.json
+++ b/dired.tmLanguage.json
@@ -28,7 +28,7 @@
       "end": "$",
       "beginCaptures": {
         "1": {
-          "name": "entity.name.namespace.file.ext.dired"
+          "name": "constant.numeric.file.ext.dired"
         }
       }
     }

--- a/dired.tmLanguage.json
+++ b/dired.tmLanguage.json
@@ -3,24 +3,34 @@
   "scopeName": "source.dired",
   "patterns": [
     {
-      "name": "entity.name.directory.dired",
-      "begin": "^ *d.*",
+      "name": "entity.directory.dired",
+      "begin": "^ *d[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +(.*)",
       "end": "$",
-      "patterns": [
-        {
-          "include": "#directory"
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directory.dired"
         }
-      ]
-    }
-  ],
-  "repository": {
-    "directory": {
-      "match": "^ *d.*$",
-      "name": "keyword"
+      }
     },
-    "hidden": {
-      "match": "^\\..*$",
-      "name": "comment"
+    {
+      "name": "entity.executable.dired",
+      "begin": "^ *[^ d]+x +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +(.+)",
+      "end": "$",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.executable.dired"
+        }
+      }
+    },
+    {
+      "name": "entity.file.ext.dired",
+      "begin": "^ *[^ d]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +.*(\\..+)",
+      "end": "$",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.namespace.file.ext.dired"
+        }
+      }
     }
-  }
+  ]
 }

--- a/dired.tmLanguage.json
+++ b/dired.tmLanguage.json
@@ -1,0 +1,26 @@
+{
+  "name": "dired",
+  "scopeName": "source.dired",
+  "patterns": [
+    {
+      "name": "entity.name.directory.dired",
+      "begin": "^ *d.*",
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#directory"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "directory": {
+      "match": "^ *d.*$",
+      "name": "keyword"
+    },
+    "hidden": {
+      "match": "^\\..*$",
+      "name": "comment"
+    }
+  }
+}

--- a/language-configure.json
+++ b/language-configure.json
@@ -1,0 +1,3 @@
+{
+  "wordPattern": ".*"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dired",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dired",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/shirou/vscode-dired/issues"
   },
-   "engines": {
+  "engines": {
     "vscode": "^1.65.0"
   },
   "categories": [
@@ -98,6 +98,20 @@
         "key": "q",
         "command": "extension.dired.close",
         "when": "dired.open && !findWidgetVisible && !inQuickOpen"
+      }
+    ],
+    "languages": [
+      {
+        "id": "dired",
+        "extensions": [""],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+       "language": "dired",
+        "scopeName": "source.dired",
+        "path": "./dired.tmLanguage.json"
       }
     ],
     "configuration": {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,8 +17,7 @@ export default class DiredProvider implements vscode.TextDocumentContentProvider
     private _show_dot_files: boolean = true;
     private _buffers: string[]; // This is a temporary buffer. Reused by multiple tabs.
 
-    constructor(fixed_window: boolean)
-    {
+    constructor(fixed_window: boolean) {
         this._fixed_window = fixed_window;
     }
 
@@ -82,8 +81,7 @@ export default class DiredProvider implements vscode.TextDocumentContentProvider
         }
     }
 
-    async createFile(filename: string)
-    {
+    async createFile(filename: string) {
         const uri = vscode.Uri.file(filename);
         const document = await vscode.workspace.openTextDocument(uri);
         await vscode.window.showTextDocument(document, { preview: false });
@@ -148,10 +146,14 @@ export default class DiredProvider implements vscode.TextDocumentContentProvider
         if (uri) {
             this.createBuffer(path)
                 .then(() => vscode.workspace.openTextDocument(uri))
-                .then(doc => vscode.window.showTextDocument(
-                    doc,
-                    this.getTextDocumentShowOptions(true)
-                ));
+                .then(doc => {
+                    vscode.window.showTextDocument(
+                        doc,
+                        this.getTextDocumentShowOptions(true)
+                    );
+                    vscode.languages.setTextDocumentLanguage(doc, "dired");
+                }
+                );
         }
     }
 
@@ -219,7 +221,7 @@ export default class DiredProvider implements vscode.TextDocumentContentProvider
             if (fileItem) {
                 if (this._show_dot_files) return true;
                 let filename = fileItem.fileName;
-                if (filename == '..' || filename == '.' ) return true;
+                if (filename == '..' || filename == '.') return true;
                 return filename.substring(0, 1) != '.';
             } else {
                 return false;


### PR DESCRIPTION
Hi, in this PR,  I added the color highlighting support for:
- Directory 
- Binary files
- File extension

Can you consider merging it?

Here is an illustration:

![vscode-dired-color](https://github.com/shirou/vscode-dired/assets/193967/4c301f06-d0d2-479e-a1d8-91d03a462499)

