### PR TITLE
Fix symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vscode-dired 
+# vscode-dired
 
 *vscode-dired* is an File Manager (or Directory Editor) for VS Code.
 
@@ -13,12 +13,11 @@ Filer used by only keyboard.
 ## Configuration
 
 - `extension.dired.open`
-  - 
 
 ## Key Binding
 
 - `crtl+x f`
-  - open dired. 
+  - open dired.
 - `+`
   - Create new directory.
 - `R`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,9 +51,9 @@ export function activate(context: vscode.ExtensionContext): ExtensionInternal {
                         if (!path) {
                             return;
                         }
-                        if (fs.lstatSync(path).isDirectory()) {
+                        if (fs.statSync(path).isDirectory()) {
                             provider.openDir(path);
-                        } else if (fs.lstatSync(path).isFile()) {
+                        } else if (fs.statSync(path).isFile()) {
                             const f = new FileItem(path, "", false, true); // Incomplete FileItem just to get URI.
                             const uri = f.uri;
                             if (uri) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -189,7 +189,7 @@ export default class DiredProvider implements vscode.TextDocumentContentProvider
     private createBuffer(dirname: string): Thenable<string[]> {
         return new Promise((resolve) => {
             let files: FileItem[] = [];
-            if (fs.lstatSync(dirname).isDirectory()) {
+            if (fs.statSync(dirname).isDirectory()) {
                 try {
                     files = this.readDir(dirname);
                 } catch (err) {


### PR DESCRIPTION
Switch from `fs.lstatSync()` to `fs.statSync()` to be able to open symlinked files and directories.